### PR TITLE
refactor: Improve security and network configuration in CDK stack

### DIFF
--- a/lib/constructs/securityConstruct.ts
+++ b/lib/constructs/securityConstruct.ts
@@ -5,8 +5,11 @@ import { aws_ec2 as ec2 } from "aws-cdk-lib";
 
 interface SecurityConstructProps {
   envKey: "dev" | "prod";
-  vpc: ec2.IVpc; // Using ec2.IVpc
-  allowedCIDR: string;
+  vpc: ec2.IVpc;
+  // Instead of 'allowedCIDR' for HTTP, we accept the ALB's Security Group
+  albSecurityGroup: ec2.ISecurityGroup;
+  // We also accept an array of IP strings for SSH
+  sshAllowedIPs: string[];
 }
 
 export class SecurityConstruct extends Construct {
@@ -15,25 +18,32 @@ export class SecurityConstruct extends Construct {
   constructor(scope: Construct, id: string, props: SecurityConstructProps) {
     super(scope, id);
 
-    // Create Security Group
+    // Create Security Group for the EC2 instance
     this.securityGroup = new ec2.SecurityGroup(this, `DifySecurityGroup-${props.envKey}`, {
       vpc: props.vpc,
       securityGroupName: `dify-security-group-${props.envKey}`,
-      description: `Allow HTTP and SSH traffic for env: ${props.envKey}`,
+      description: `Allow HTTP (from ALB only) and SSH (from 4 IPs) for env: ${props.envKey}`,
       allowAllOutbound: true,
     });
 
-    // Inbound Rules
+    //
+    // HTTP rule: Only allow inbound port 80 from the ALB's SG
+    //
     this.securityGroup.addIngressRule(
-      ec2.Peer.ipv4(props.allowedCIDR),
+      ec2.Peer.securityGroupId(props.albSecurityGroup.securityGroupId),
       ec2.Port.tcp(80),
-      "Allow HTTP traffic from allowed CIDR"
+      "Allow HTTP traffic only from the load balancer security group"
     );
 
-    this.securityGroup.addIngressRule(
-      ec2.Peer.ipv4(props.allowedCIDR),
-      ec2.Port.tcp(22),
-      "Allow SSH traffic from allowed CIDR"
-    );
+    //
+    // SSH rules: We allow port 22 from exactly 4 IP addresses
+    //
+    for (const ip of props.sshAllowedIPs) {
+      this.securityGroup.addIngressRule(
+        ec2.Peer.ipv4(ip),
+        ec2.Port.tcp(22),
+        `Allow SSH traffic from ${ip}`
+      );
+    }
   }
 }


### PR DESCRIPTION
- Modify security group and network configuration to use a centralized ALB security group
- Replace hardcoded CIDR with explicit SSH allowed IP list
- Update LoadBalancerConstruct and SecurityConstruct to use shared security group
- Simplify network configuration by removing unnecessary parameters